### PR TITLE
Add CSV formatter

### DIFF
--- a/youtube_transcript_api/formatters.py
+++ b/youtube_transcript_api/formatters.py
@@ -1,4 +1,6 @@
 import json
+import csv
+import io
 
 import pprint
 from typing import List, Iterable
@@ -65,6 +67,23 @@ class JSONFormatter(Formatter):
         return json.dumps(
             [transcript.to_raw_data() for transcript in transcripts], **kwargs
         )
+
+
+class CSVFormatter(Formatter):
+    def _format(self, transcripts: Iterable[FetchedTranscript], **kwargs) -> str:
+        output = io.StringIO(newline="")
+        writer = csv.writer(output, lineterminator="\n", **kwargs)
+        writer.writerow(["text", "start", "duration"])
+        for transcript in transcripts:
+            for snippet in transcript:
+                writer.writerow([snippet.text, snippet.start, snippet.duration])
+        return output.getvalue()
+
+    def format_transcript(self, transcript: FetchedTranscript, **kwargs) -> str:
+        return self._format([transcript], **kwargs)
+
+    def format_transcripts(self, transcripts: List[FetchedTranscript], **kwargs) -> str:
+        return self._format(transcripts, **kwargs)
 
 
 class TextFormatter(Formatter):
@@ -184,6 +203,7 @@ class FormatterLoader:
         "text": TextFormatter,
         "webvtt": WebVTTFormatter,
         "srt": SRTFormatter,
+        "csv": CSVFormatter,
     }
 
     class UnknownFormatterType(Exception):

--- a/youtube_transcript_api/test/test_formatters.py
+++ b/youtube_transcript_api/test/test_formatters.py
@@ -10,6 +10,7 @@ from youtube_transcript_api.formatters import (
     Formatter,
     JSONFormatter,
     TextFormatter,
+    CSVFormatter,
     SRTFormatter,
     WebVTTFormatter,
     PrettyPrintFormatter,
@@ -141,6 +142,21 @@ class TestFormatters(TestCase):
             content,
             formatted_single_transcript + "\n\n\n" + formatted_single_transcript,
         )
+
+    def test_csv_formatter(self):
+        content = CSVFormatter().format_transcript(self.transcript)
+        lines = content.split("\n")
+
+        self.assertEqual(lines[0], "text,start,duration")
+        self.assertEqual(lines[1].split(","), [self.transcript_raw[0]["text"], str(self.transcript_raw[0]["start"]), str(self.transcript_raw[0]["duration"])])
+
+    def test_csv_formatter_many(self):
+        formatter = CSVFormatter()
+        content = formatter.format_transcripts(self.transcripts)
+        lines = [l for l in content.split("\n") if l]
+        # header + 2 transcripts * len(snippets)
+        expected_rows = 1 + len(self.transcript_raw) * len(self.transcripts)
+        self.assertEqual(len(lines), expected_rows)
 
     def test_formatter_loader(self):
         loader = FormatterLoader()


### PR DESCRIPTION
## Summary
- add CSVFormatter for exporting transcripts to CSV
- support `--format csv` via FormatterLoader
- test CSV formatter

## Testing
- `pytest youtube_transcript_api/test/test_formatters.py::TestFormatters::test_csv_formatter -q`
- `pytest youtube_transcript_api/test/test_formatters.py::TestFormatters::test_csv_formatter_many -q`
- `pytest -q` *(fails: ConnectionError to youtube.com)*

------
https://chatgpt.com/codex/tasks/task_e_684b4e6f54348326bb1e65e6f90b22fd