### PR TITLE
Add transcript filtering capabilities

### DIFF
--- a/youtube_transcript_api/_cli.py
+++ b/youtube_transcript_api/_cli.py
@@ -89,7 +89,20 @@ class YouTubeTranscriptCli:
         if parsed_args.translate:
             transcript = transcript.translate(parsed_args.translate)
 
-        return transcript.fetch()
+        fetched = transcript.fetch()
+
+        start = parsed_args.start_time if parsed_args.start_time is not None else 0.0
+        end = parsed_args.end_time if parsed_args.end_time is not None else float("inf")
+        if parsed_args.start_time is not None or parsed_args.end_time is not None:
+            fetched = fetched.filter_by_time_range(start, end)
+
+        if parsed_args.keyword:
+            fetched = fetched.filter_by_keyword(parsed_args.keyword)
+
+        if parsed_args.merge_snippets:
+            fetched = fetched.merge_continuous_snippets()
+
+        return fetched
 
     def _parse_args(self):
         parser = argparse.ArgumentParser(
@@ -175,6 +188,31 @@ class YouTubeTranscriptCli:
             default="",
             metavar="URL",
             help="Use the specified HTTPS proxy.",
+        )
+        parser.add_argument(
+            "--start-time",
+            type=float,
+            default=None,
+            help="Only include transcript snippets starting after this time (seconds).",
+        )
+        parser.add_argument(
+            "--end-time",
+            type=float,
+            default=None,
+            help="Only include transcript snippets starting before this time (seconds).",
+        )
+        parser.add_argument(
+            "--keyword",
+            type=str,
+            default="",
+            help="Filter transcript snippets to those containing this keyword.",
+        )
+        parser.add_argument(
+            "--merge-snippets",
+            action="store_const",
+            const=True,
+            default=False,
+            help="Merge continuous transcript snippets before output.",
         )
         # Cookie auth has been temporarily disabled, as it is not working properly with
         # YouTube's most recent changes.

--- a/youtube_transcript_api/_transcripts.py
+++ b/youtube_transcript_api/_transcripts.py
@@ -71,6 +71,102 @@ class FetchedTranscript:
     def to_raw_data(self) -> List[Dict]:
         return [asdict(snippet) for snippet in self]
 
+    def filter_by_time_range(
+        self, start_time: float, end_time: float
+    ) -> "FetchedTranscript":
+        """Return a new ``FetchedTranscript`` containing only snippets within the
+        provided time range.
+
+        ``start_time`` is inclusive, ``end_time`` is exclusive. If ``start_time``
+        is greater than ``end_time`` an empty transcript is returned.
+        """
+
+        if start_time > end_time:
+            filtered_snippets: List[FetchedTranscriptSnippet] = []
+        else:
+            filtered_snippets = [
+                snippet
+                for snippet in self.snippets
+                if start_time <= snippet.start < end_time
+            ]
+
+        return FetchedTranscript(
+            snippets=filtered_snippets,
+            video_id=self.video_id,
+            language=self.language,
+            language_code=self.language_code,
+            is_generated=self.is_generated,
+        )
+
+    def filter_by_keyword(
+        self, keyword: str, case_sensitive: bool = False
+    ) -> "FetchedTranscript":
+        """Return a new ``FetchedTranscript`` containing only snippets whose
+        text includes ``keyword``.
+
+        If ``case_sensitive`` is ``False`` (the default) the comparison is made
+        case insensitively.
+        """
+
+        if keyword == "":
+            filtered_snippets = list(self.snippets)
+        else:
+            if case_sensitive:
+                filtered_snippets = [
+                    snippet for snippet in self.snippets if keyword in snippet.text
+                ]
+            else:
+                kw_lower = keyword.lower()
+                filtered_snippets = [
+                    snippet
+                    for snippet in self.snippets
+                    if kw_lower in snippet.text.lower()
+                ]
+
+        return FetchedTranscript(
+            snippets=filtered_snippets,
+            video_id=self.video_id,
+            language=self.language,
+            language_code=self.language_code,
+            is_generated=self.is_generated,
+        )
+
+    def merge_continuous_snippets(self, max_gap: float = 0.5) -> "FetchedTranscript":
+        """Merge consecutive snippets if the gap between them does not exceed
+        ``max_gap`` seconds.
+        """
+
+        if not self.snippets:
+            merged_snippets: List[FetchedTranscriptSnippet] = []
+        else:
+            merged_snippets = []
+            current = FetchedTranscriptSnippet(
+                text=self.snippets[0].text,
+                start=self.snippets[0].start,
+                duration=self.snippets[0].duration,
+            )
+            for snippet in self.snippets[1:]:
+                gap = snippet.start - (current.start + current.duration)
+                if gap <= max_gap:
+                    current.text += " " + snippet.text
+                    current.duration = snippet.start + snippet.duration - current.start
+                else:
+                    merged_snippets.append(current)
+                    current = FetchedTranscriptSnippet(
+                        text=snippet.text,
+                        start=snippet.start,
+                        duration=snippet.duration,
+                    )
+            merged_snippets.append(current)
+
+        return FetchedTranscript(
+            snippets=merged_snippets,
+            video_id=self.video_id,
+            language=self.language,
+            language_code=self.language_code,
+            is_generated=self.is_generated,
+        )
+
 
 @dataclass
 class _TranslationLanguage:

--- a/youtube_transcript_api/test/test_cli.py
+++ b/youtube_transcript_api/test/test_cli.py
@@ -41,6 +41,16 @@ class TestYouTubeTranscriptCli(TestCase):
                 video_id="GJLlxj_dtq8",
             )
         )
+        self.fetched_transcript = self.transcript_mock.fetch.return_value
+        self.fetched_transcript.filter_by_time_range = MagicMock(
+            return_value=self.fetched_transcript
+        )
+        self.fetched_transcript.filter_by_keyword = MagicMock(
+            return_value=self.fetched_transcript
+        )
+        self.fetched_transcript.merge_continuous_snippets = MagicMock(
+            return_value=self.fetched_transcript
+        )
         self.transcript_mock.translate = MagicMock(return_value=self.transcript_mock)
 
         self.transcript_list_mock = MagicMock()
@@ -233,6 +243,15 @@ class TestYouTubeTranscriptCli(TestCase):
         self.assertTrue(parsed_args.exclude_manually_created)
         self.assertTrue(parsed_args.exclude_generated)
 
+    def test_argument_parsing__filters(self):
+        parsed_args = YouTubeTranscriptCli(
+            "v1 --start-time 1.0 --end-time 3.0 --keyword test --merge-snippets".split()
+        )._parse_args()
+        self.assertEqual(parsed_args.start_time, 1.0)
+        self.assertEqual(parsed_args.end_time, 3.0)
+        self.assertEqual(parsed_args.keyword, "test")
+        self.assertTrue(parsed_args.merge_snippets)
+
     def test_run(self):
         YouTubeTranscriptCli("v1 v2 --languages de en".split()).run()
 
@@ -278,6 +297,15 @@ class TestYouTubeTranscriptCli(TestCase):
         (YouTubeTranscriptCli("v1 v2 --languages de en --translate cz".split()).run(),)
 
         self.transcript_mock.translate.assert_any_call("cz")
+
+    def test_run__filters(self):
+        YouTubeTranscriptCli(
+            "v1 --start-time 1.0 --end-time 2.0 --keyword test --merge-snippets".split()
+        ).run()
+
+        self.fetched_transcript.filter_by_time_range.assert_any_call(1.0, 2.0)
+        self.fetched_transcript.filter_by_keyword.assert_any_call("test")
+        self.fetched_transcript.merge_continuous_snippets.assert_any_call()
 
     def test_run__list_transcripts(self):
         YouTubeTranscriptCli("--list-transcripts v1 v2".split()).run()
@@ -333,7 +361,7 @@ class TestYouTubeTranscriptCli(TestCase):
     )
     def test_run__cookies(self):
         YouTubeTranscriptCli(
-            ("v1 v2 --languages de en " "--cookies blahblah.txt").split()
+            ("v1 v2 --languages de en --cookies blahblah.txt").split()
         ).run()
 
         YouTubeTranscriptApi.__init__.assert_any_call(

--- a/youtube_transcript_api/test/test_transcripts.py
+++ b/youtube_transcript_api/test/test_transcripts.py
@@ -1,0 +1,59 @@
+import unittest
+from youtube_transcript_api import FetchedTranscript, FetchedTranscriptSnippet
+
+
+class TestFetchedTranscriptFiltering(unittest.TestCase):
+    def setUp(self):
+        self.transcript = FetchedTranscript(
+            snippets=[
+                FetchedTranscriptSnippet(text="first snippet", start=0.0, duration=1.0),
+                FetchedTranscriptSnippet(
+                    text="second snippet", start=1.5, duration=1.0
+                ),
+                FetchedTranscriptSnippet(text="third keyword", start=3.0, duration=2.0),
+            ],
+            language="English",
+            language_code="en",
+            is_generated=False,
+            video_id="vid",
+        )
+
+    def test_filter_by_time_range(self):
+        filtered = self.transcript.filter_by_time_range(1.0, 3.1)
+        self.assertEqual(len(filtered), 2)
+        self.assertEqual(filtered[0].text, "second snippet")
+        self.assertEqual(filtered[1].text, "third keyword")
+
+    def test_filter_by_time_range_empty(self):
+        filtered = self.transcript.filter_by_time_range(5.0, 6.0)
+        self.assertEqual(len(filtered), 0)
+
+    def test_filter_by_keyword(self):
+        filtered = self.transcript.filter_by_keyword("keyword")
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0].text, "third keyword")
+
+    def test_filter_by_keyword_case_sensitive(self):
+        filtered = self.transcript.filter_by_keyword("Keyword", case_sensitive=True)
+        self.assertEqual(len(filtered), 0)
+
+    def test_merge_continuous_snippets(self):
+        merged = self.transcript.merge_continuous_snippets()
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0].text, "first snippet second snippet third keyword")
+        self.assertAlmostEqual(merged[0].duration, 5.0)
+
+    def test_merge_continuous_snippets_empty(self):
+        empty = FetchedTranscript(
+            snippets=[],
+            language="en",
+            language_code="en",
+            is_generated=False,
+            video_id="vid",
+        )
+        merged = empty.merge_continuous_snippets()
+        self.assertEqual(len(merged), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add filtering helpers to `FetchedTranscript`
- enable transcript filtering options for the CLI
- expand CLI tests for new options
- test `FetchedTranscript` filter helpers

## Testing
- `poetry run coverage run -m pytest youtube_transcript_api` *(fails: connection errors)*
- `poetry run pytest youtube_transcript_api/test/test_transcripts.py`

------
https://chatgpt.com/codex/tasks/task_e_684b5d692aec8326bf9e77cde8d48c92