### PR TITLE
Add transcript search feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,17 @@ transcript.fetch()
 
 This returns a `FetchedTranscript` object, just like `YouTubeTranscriptApi().fetch()` does.
 
+### Search transcript
+
+You can search within a transcript for keywords or regular expressions:
+
+```python
+transcript = ytt_api.fetch(video_id)
+results = transcript.search_in_transcript("python")
+for result in results:
+    print(f"{result.start}s: {result.matched_text}")
+```
+
 ### Translate transcript
 
 YouTube has a feature which allows you to automatically translate subtitles. This module also makes it possible to 
@@ -487,7 +498,13 @@ Translating transcripts using the CLI is also possible:
 
 ```  
 youtube_transcript_api <first_video_id> <second_video_id> ... --languages en --translate de
-```  
+```
+
+Searching within transcripts can be done as well:
+
+```
+youtube_transcript_api <video_id> --search "machine learning" --case-sensitive
+```
 
 If you are not sure which languages are available for a given video you can call, to list all available transcripts:
 

--- a/youtube_transcript_api/__init__.py
+++ b/youtube_transcript_api/__init__.py
@@ -5,6 +5,7 @@ from ._transcripts import (
     Transcript,
     FetchedTranscript,
     FetchedTranscriptSnippet,
+    SearchResult,
 )
 from ._errors import (
     YouTubeTranscriptApiException,

--- a/youtube_transcript_api/_cli.py
+++ b/youtube_transcript_api/_cli.py
@@ -61,6 +61,23 @@ class YouTubeTranscriptCli:
                 print_sections.extend(
                     str(transcript_list) for transcript_list in transcripts
                 )
+            elif parsed_args.search:
+                results = []
+                for transcript in transcripts:
+                    results.extend(
+                        transcript.search_in_transcript(
+                            parsed_args.search,
+                            regex=parsed_args.regex,
+                            case_sensitive=parsed_args.case_sensitive,
+                        )
+                    )
+                if results:
+                    print_sections.extend(
+                        f"{result.start:.2f}-{result.end:.2f}s: {result.context_before} [{result.matched_text}] {result.context_after}"
+                        for result in results
+                    )
+                else:
+                    print_sections.append("No matches found.")
             else:
                 print_sections.append(
                     FormatterLoader()
@@ -142,6 +159,25 @@ class YouTubeTranscriptCli:
             type=str,
             default="pretty",
             choices=tuple(FormatterLoader.TYPES.keys()),
+        )
+        parser.add_argument(
+            "--search",
+            default=None,
+            help="Keyword to search for within the fetched transcripts.",
+        )
+        parser.add_argument(
+            "--regex",
+            action="store_const",
+            const=True,
+            default=False,
+            help="Interpret the search keyword as a regular expression.",
+        )
+        parser.add_argument(
+            "--case-sensitive",
+            action="store_const",
+            const=True,
+            default=False,
+            help="Perform a case sensitive search.",
         )
         parser.add_argument(
             "--translate",

--- a/youtube_transcript_api/_transcripts.py
+++ b/youtube_transcript_api/_transcripts.py
@@ -3,7 +3,7 @@ from enum import Enum
 from itertools import chain
 
 from html import unescape
-from typing import List, Dict, Iterator, Iterable, Pattern, Optional
+from typing import List, Dict, Iterator, Iterable, Pattern, Optional, Tuple
 
 from defusedxml import ElementTree
 
@@ -70,6 +70,88 @@ class FetchedTranscript:
 
     def to_raw_data(self) -> List[Dict]:
         return [asdict(snippet) for snippet in self]
+
+    def search_in_transcript(
+        self,
+        query: str,
+        *,
+        regex: bool = False,
+        case_sensitive: bool = False,
+    ) -> List["SearchResult"]:
+        """Search through the transcript for ``query``.
+
+        :param query: The keyword or regular expression to search for.
+        :param regex: Interpret ``query`` as a regular expression if ``True``.
+        :param case_sensitive: Perform case sensitive matching if ``True``.
+        :return: A list of :class:`SearchResult` objects describing all matches.
+        :raises ValueError: If ``query`` is an invalid regular expression.
+        """
+
+        flags = 0 if case_sensitive else re.IGNORECASE
+        if regex:
+            try:
+                pattern = re.compile(query, flags)
+            except re.error as exc:
+                raise ValueError(f"Invalid regex pattern: {exc}") from exc
+        else:
+            pattern = re.compile(re.escape(query), flags)
+
+        full_text = ""
+        ranges: List[Tuple[int, int, FetchedTranscriptSnippet]] = []
+        for snippet in self.snippets:
+            start = len(full_text)
+            full_text += snippet.text + "\n"
+            end = len(full_text)
+            ranges.append((start, end, snippet))
+
+        word_iter = list(re.finditer(r"\S+", full_text))
+        words = [m.group(0) for m in word_iter]
+        word_positions = [m.start() for m in word_iter]
+
+        results: List[SearchResult] = []
+        for match in pattern.finditer(full_text):
+            char_index = match.start()
+            snippet = next(sn for start, end, sn in ranges if start <= char_index < end)
+            start_time = snippet.start
+            end_time = snippet.start + snippet.duration
+
+            word_index = next(
+                (i for i, pos in enumerate(word_positions) if pos >= char_index),
+                len(words),
+            )
+            match_words = re.findall(r"\S+", match.group(0))
+            before_words = words[max(0, word_index - 10) : word_index]
+            after_words = words[
+                word_index + len(match_words) : word_index + len(match_words) + 10
+            ]
+
+            results.append(
+                SearchResult(
+                    matched_text=match.group(0),
+                    start=start_time,
+                    end=end_time,
+                    context_before=" ".join(before_words),
+                    context_after=" ".join(after_words),
+                )
+            )
+
+        return results
+
+
+@dataclass
+class SearchResult:
+    """Represents a search result returned by :func:`FetchedTranscript.search_in_transcript`."""
+
+    matched_text: str
+    """The text that matched the search query."""
+    start: float
+    """The start time of the snippet containing the match."""
+    end: float
+    """The end time of the snippet containing the match."""
+    context_before: str
+    """Up to ten words that appear before the match."""
+    context_after: str
+    """Up to ten words that appear after the match."""
 
 
 @dataclass

--- a/youtube_transcript_api/test/test_cli.py
+++ b/youtube_transcript_api/test/test_cli.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import json
 
@@ -9,6 +9,7 @@ from youtube_transcript_api import (
     VideoUnavailable,
     FetchedTranscript,
     FetchedTranscriptSnippet,
+    SearchResult,
 )
 from youtube_transcript_api._cli import YouTubeTranscriptCli
 
@@ -43,6 +44,12 @@ class TestYouTubeTranscriptCli(TestCase):
         )
         self.transcript_mock.translate = MagicMock(return_value=self.transcript_mock)
 
+        self.search_patch = patch(
+            "youtube_transcript_api._transcripts.FetchedTranscript.search_in_transcript",
+            MagicMock(return_value=[]),
+        )
+        self.mock_search = self.search_patch.start()
+
         self.transcript_list_mock = MagicMock()
         self.transcript_list_mock.find_generated_transcript = MagicMock(
             return_value=self.transcript_mock
@@ -56,6 +63,9 @@ class TestYouTubeTranscriptCli(TestCase):
 
         YouTubeTranscriptApi.__init__ = MagicMock(return_value=None)
         YouTubeTranscriptApi.list = MagicMock(return_value=self.transcript_list_mock)
+
+    def tearDown(self):
+        self.search_patch.stop()
 
     def test_argument_parsing(self):
         parsed_args = YouTubeTranscriptCli(
@@ -95,6 +105,17 @@ class TestYouTubeTranscriptCli(TestCase):
         self.assertEqual(parsed_args.languages, ["de", "en"])
         self.assertEqual(parsed_args.http_proxy, "http://user:pass@domain:port")
         self.assertEqual(parsed_args.https_proxy, "https://user:pass@domain:port")
+
+        parsed_args = YouTubeTranscriptCli("v1 --search test".split())._parse_args()
+        self.assertEqual(parsed_args.search, "test")
+        self.assertFalse(parsed_args.regex)
+        self.assertFalse(parsed_args.case_sensitive)
+
+        parsed_args = YouTubeTranscriptCli(
+            "v1 --search test --regex --case-sensitive".split()
+        )._parse_args()
+        self.assertTrue(parsed_args.regex)
+        self.assertTrue(parsed_args.case_sensitive)
 
         parsed_args = YouTubeTranscriptCli(
             "v1 v2 --languages de en --format json "
@@ -279,6 +300,33 @@ class TestYouTubeTranscriptCli(TestCase):
 
         self.transcript_mock.translate.assert_any_call("cz")
 
+    def test_run__search(self):
+        self.mock_search.return_value = [
+            SearchResult(
+                matched_text="test",
+                start=0.0,
+                end=1.54,
+                context_before="",
+                context_after="",
+            )
+        ]
+
+        output = YouTubeTranscriptCli("v1 --search test".split()).run()
+
+        self.mock_search.assert_called_with(
+            "test",
+            regex=False,
+            case_sensitive=False,
+        )
+        self.assertIn("0.00-1.54s", output)
+
+    def test_run__search_no_results(self):
+        self.mock_search.return_value = []
+
+        output = YouTubeTranscriptCli("v1 --search missing".split()).run()
+
+        self.assertIn("No matches found.", output)
+
     def test_run__list_transcripts(self):
         YouTubeTranscriptCli("--list-transcripts v1 v2".split()).run()
 
@@ -333,7 +381,7 @@ class TestYouTubeTranscriptCli(TestCase):
     )
     def test_run__cookies(self):
         YouTubeTranscriptCli(
-            ("v1 v2 --languages de en " "--cookies blahblah.txt").split()
+            ("v1 v2 --languages de en --cookies blahblah.txt").split()
         ).run()
 
         YouTubeTranscriptApi.__init__.assert_any_call(

--- a/youtube_transcript_api/test/test_search.py
+++ b/youtube_transcript_api/test/test_search.py
@@ -1,0 +1,56 @@
+import unittest
+
+from youtube_transcript_api import (
+    FetchedTranscript,
+    FetchedTranscriptSnippet,
+    SearchResult,
+)
+
+
+class TestSearchInTranscript(unittest.TestCase):
+    def setUp(self):
+        self.transcript = FetchedTranscript(
+            snippets=[
+                FetchedTranscriptSnippet(
+                    text="Hey, this is just a test", start=0.0, duration=1.54
+                ),
+                FetchedTranscriptSnippet(
+                    text="this is not the original transcript",
+                    start=1.54,
+                    duration=4.16,
+                ),
+                FetchedTranscriptSnippet(
+                    text="just something shorter, I made up for testing",
+                    start=5.7,
+                    duration=3.239,
+                ),
+            ],
+            language="English",
+            language_code="en",
+            is_generated=False,
+            video_id="vid",
+        )
+
+    def test_search_keyword(self):
+        results = self.transcript.search_in_transcript("test")
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].matched_text.lower(), "test")
+        self.assertAlmostEqual(results[0].start, 0.0)
+        self.assertAlmostEqual(results[0].end, 1.54)
+
+    def test_search_case_sensitive(self):
+        results = self.transcript.search_in_transcript("Test", case_sensitive=True)
+        self.assertEqual(len(results), 0)
+
+    def test_search_regex(self):
+        results = self.transcript.search_in_transcript(r"test\w+", regex=True)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].matched_text, "testing")
+
+    def test_search_invalid_regex(self):
+        with self.assertRaises(ValueError):
+            self.transcript.search_in_transcript("([)", regex=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support searching transcript content by keyword or regex
- expose `SearchResult` in public API
- add CLI flags for searching transcripts
- document search feature in README
- test search functionality and CLI integration

## Testing
- `ruff format youtube_transcript_api`
- `ruff check youtube_transcript_api`
- `HTTP_PROXY= HTTPS_PROXY= http_proxy= https_proxy= pytest youtube_transcript_api` *(fails: 5 failed, 100 passed, 7 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684f3a96943c8326a858c6d567c624bd