### PR TITLE
Fix formatting bugs in WebVTT and SRT formatters

### DIFF
--- a/youtube_transcript_api/formatters.py
+++ b/youtube_transcript_api/formatters.py
@@ -161,12 +161,12 @@ class SRTFormatter(_TextBasedFormatter):
     def _format_transcript_helper(
         self, i: int, time_text: str, snippet: FetchedTranscriptSnippet
     ) -> str:
-        return "{}\n{}\n{}".format(i, time_text, snippet.text)
+        return "{}\n{}\n{}".format(i + 1, time_text, snippet.text)
 
 
 class WebVTTFormatter(_TextBasedFormatter):
     def _format_timestamp(self, hours: int, mins: int, secs: int, ms: int) -> str:
-        return "{:02d}:{:02d}:{:02d},{:03d}".format(hours, mins, secs, ms)
+        return "{:02d}:{:02d}:{:02d}.{:03d}".format(hours, mins, secs, ms)
 
     def _format_transcript_header(self, lines: Iterable[str]) -> str:
         return "WEBVTT\n\n" + "\n\n".join(lines) + "\n"

--- a/youtube_transcript_api/test/test_formatters.py
+++ b/youtube_transcript_api/test/test_formatters.py
@@ -86,6 +86,7 @@ class TestFormatters(TestCase):
         # test starting lines
         self.assertEqual(lines[0], "WEBVTT")
         self.assertEqual(lines[1], "")
+        self.assertEqual(lines[2], "00:00:00.000 --> 00:00:01.500")
 
     def test_webvtt_formatter_ending(self):
         content = WebVTTFormatter().format_transcript(self.transcript)


### PR DESCRIPTION
## Summary
- correct millisecond separator in WebVTT output
- start numbering from 1 in SRT formatter
- check first WebVTT timestamp in tests

## Testing
- `pytest youtube_transcript_api/test/test_formatters.py -q`
- `pip install -e . -q` *(setup)*


------
https://chatgpt.com/codex/tasks/task_e_684f3d8f4fd083269de202dd212491ca